### PR TITLE
Exclude byte-buddy versions with jdk suffix from Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>jenkinsci/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["net.bytebuddy:byte-buddy"],
+      "allowedVersions": "!/-jdk\\d+$/"
+    }
   ]
 }


### PR DESCRIPTION
Byte Buddy publishes JDK5-compatible variants on Maven Central with a `-jdk5` version suffix (e.g. `1.18.11-jdk5`), and Renovate's Maven versioning considers them newer than the plain release, leading to unwanted update PRs like #133.

This adds a `packageRules` entry with a negated `allowedVersions` regex so any `net.bytebuddy:byte-buddy` version ending in `-jdk<N>` is excluded, while plain releases (e.g. `1.18.12`) are still proposed normally.

Config validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)